### PR TITLE
v2.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/msp1974/homeassistant-jlrincontrol)](https://github.com/msp1974/homeassistant-jlrincontrol/blob/master/LICENSE)
 [![GitHub release](https://img.shields.io/github/release/msp1974/homeassistant-jlrincontrol)](https://GitHub.com/msp1974/homeassistant-jlrincontrol/releases/)
 
-# JLR Home Assistant Integration (v2.0.1)
+# JLR Home Assistant Integration (v2.0.2)
 
 This repository contains a Home Assistant integration for the Jaguar Landrover InControl system, allowing visibility of key vehicle information and control of enabled services.
 
@@ -123,6 +123,13 @@ This integration uses the jlrpy api written by [ardevd](https://github.com/ardev
 2. To enable logging of the attributes and status data in the debug log, set the debug data option in config options with debugging turned on as above.
 
 # Change Log
+
+## v2.0.2
+
+- Fixed: error when locking/unlocking via lock device sensor. Issue #39
+- Fixed: not updating from server after lock/unlock call from device sensor
+- Updated: improved handling of service call returns
+- Updated: get status update from server when service call fails
 
 ## v2.0.1
 

--- a/custom_components/jlrincontrol/__init__.py
+++ b/custom_components/jlrincontrol/__init__.py
@@ -451,7 +451,6 @@ class JLRApiHandler:
             jlr_service = JLRService(self.hass, self.config_entry, vin)
             status = await jlr_service.async_call_service(**kwargs)
 
-            # Call update on return of monitorif successful
             if status and status == "Successful":
                 _LOGGER.debug(
                     "Service call {} on vehicle {} successful. ".format(
@@ -460,7 +459,8 @@ class JLRApiHandler:
                         self.vehicles[vin].attributes.get("nickname"),
                     )
                 )
-                await self.async_update()
+            # Call update on return of monitor
+            await self.async_update()
 
     async def async_update(self):
         try:

--- a/custom_components/jlrincontrol/const.py
+++ b/custom_components/jlrincontrol/const.py
@@ -14,7 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = "jlrincontrol"
 DATA_JLR_CONFIG = "jlrincontrol_config"
 JLR_DATA = "jlr_data"
-VERSION = "2.0"
+VERSION = "2.0.2"
 
 DEFAULT_SCAN_INTERVAL = 5
 MIN_SCAN_INTERVAL = 1

--- a/custom_components/jlrincontrol/lock.py
+++ b/custom_components/jlrincontrol/lock.py
@@ -45,7 +45,9 @@ class JLRLock(JLREntity, LockEntity):
             kwargs["service_name"] = "lock"
             kwargs["service_code"] = "RDL"
             kwargs["pin"] = p
-            jlr_service = JLRService(self._hass, self.config_entry, self._vin)
+            jlr_service = JLRService(
+                self._hass, self._data.config_entry, self._vin
+            )
             await jlr_service.async_call_service(**kwargs)
         else:
             _LOGGER.warning("Cannot lock vehicle - pin not set in options.")
@@ -59,7 +61,9 @@ class JLRLock(JLREntity, LockEntity):
             kwargs["service_name"] = "unlock"
             kwargs["service_code"] = "RDU"
             kwargs["pin"] = p
-            jlr_service = JLRService(self._hass, self.config_entry, self._vin)
+            jlr_service = JLRService(
+                self._hass, self._data.config_entry, self._vin
+            )
             await jlr_service.async_call_service(**kwargs)
         else:
             _LOGGER.warning("Cannot unlock vehicle - pin not set in options.")

--- a/custom_components/jlrincontrol/lock.py
+++ b/custom_components/jlrincontrol/lock.py
@@ -49,6 +49,7 @@ class JLRLock(JLREntity, LockEntity):
                 self._hass, self._data.config_entry, self._vin
             )
             await jlr_service.async_call_service(**kwargs)
+            await self._data.async_update()
         else:
             _LOGGER.warning("Cannot lock vehicle - pin not set in options.")
 
@@ -65,6 +66,7 @@ class JLRLock(JLREntity, LockEntity):
                 self._hass, self._data.config_entry, self._vin
             )
             await jlr_service.async_call_service(**kwargs)
+            await self._data.async_update()
         else:
             _LOGGER.warning("Cannot unlock vehicle - pin not set in options.")
 

--- a/custom_components/jlrincontrol/services.py
+++ b/custom_components/jlrincontrol/services.py
@@ -182,13 +182,13 @@ class JLRService:
                 await asyncio.sleep(5)
                 result = await self.async_check_service_status(service_id)
                 status = result.get("status")
-            if status and status == "Successful":
+            if status and status in ["Successful", "MessageDelivered"]:
                 _LOGGER.info(
                     "Service call ({}) to vehicle {} was successful".format(
                         self.service_name, self.nickname
                     )
                 )
-                return status
+                return "Successful"
             else:
                 _LOGGER.info(
                     "InControl service call ({}) to vehicle {} ".format(


### PR DESCRIPTION
- Fixed: error when locking/unlocking via lock device sensor. Issue #39
- Fixed: not updating from server after lock/unlock call from device sensor
- Updated: improved handling of service call returns
- Updated: get status update from server when service call fails