### PR TITLE
chore(constants): migrate deprecated constants to enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![GitHub license](https://img.shields.io/github/license/msp1974/homeassistant-jlrincontrol)](https://github.com/msp1974/homeassistant-jlrincontrol/blob/master/LICENSE)
 [![GitHub release](https://img.shields.io/github/release/msp1974/homeassistant-jlrincontrol)](https://GitHub.com/msp1974/homeassistant-jlrincontrol/releases/)
 
-# JLR Home Assistant Integration (v2.2.4)
+# JLR Home Assistant Integration (v3.0.0)
 
 This repository contains a Home Assistant integration for the Jaguar Landrover InControl system, allowing visibility of key vehicle information and control of enabled services.
 
-Due to changes in Home Assistant, this integration requires a minimum of HA v2022.10.
+Due to changes in Home Assistant, this integration requires a minimum of HA `v2022.11`.
 
 # Functionality
 
@@ -133,6 +133,11 @@ This integration uses the jlrpy api written by [ardevd](https://github.com/ardev
 2. To enable logging of the attributes and status data in the debug log, set the debug data option in config options with debugging turned on as above.
 
 # Change Log
+
+## v3.0.0
+- Fixed: migrate deprecated HA constants with enums [#106](https://github.com/msp1974/homeassistant-jlrincontrol/issues/106) 
+introduced in HA `v2022.11` and deprecation warnings in HA `v2024.1`. This integration requires from now minium version
+`v2022.11` of HA.
 
 ## v2.2.4
 - Bump jlrpy to v1.5.2 to fix lock/unlock [#102](https://github.com/msp1974/homeassistant-jlrincontrol/issues/102)

--- a/custom_components/jlrincontrol/__init__.py
+++ b/custom_components/jlrincontrol/__init__.py
@@ -32,8 +32,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     UnitOfLength,
     UnitOfPressure,
-    TEMP_CELSIUS,
-    TEMP_FAHRENHEIT,
+    UnitOfTemperature,
 )
 from homeassistant.core import callback
 from homeassistant.helpers.discovery import async_load_platform

--- a/custom_components/jlrincontrol/__init__.py
+++ b/custom_components/jlrincontrol/__init__.py
@@ -30,8 +30,7 @@ from homeassistant.const import (
     CONF_RESOURCES,
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
-    LENGTH_KILOMETERS,
-    LENGTH_MILES,
+    UnitOfLength,
     UnitOfPressure,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
@@ -113,7 +112,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Required(CONF_PASSWORD): cv.string,
                 vol.Required(CONF_USE_CHINA_SERVERS, default=False): cv.boolean,
                 vol.Optional(CONF_DISTANCE_UNIT): vol.In(
-                    [LENGTH_KILOMETERS, LENGTH_MILES]
+                    [UnitOfLength.KILOMETERS, UnitOfLength.MILES]
                 ),
                 vol.Optional(CONF_PRESSURE_UNIT): vol.In(
                     [UnitOfPressure.BAR, UnitOfPressure.PSI]

--- a/custom_components/jlrincontrol/__init__.py
+++ b/custom_components/jlrincontrol/__init__.py
@@ -32,9 +32,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     LENGTH_KILOMETERS,
     LENGTH_MILES,
-    PRESSURE_BAR,
-    PRESSURE_PA,
-    PRESSURE_PSI,
+    UnitOfPressure,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
 )
@@ -118,7 +116,7 @@ CONFIG_SCHEMA = vol.Schema(
                     [LENGTH_KILOMETERS, LENGTH_MILES]
                 ),
                 vol.Optional(CONF_PRESSURE_UNIT): vol.In(
-                    [PRESSURE_BAR, PRESSURE_PSI]
+                    [UnitOfPressure.BAR, UnitOfPressure.PSI]
                 ),
                 vol.Optional(CONF_DEBUG_DATA, default=False): cv.boolean,
                 vol.Optional(CONF_PIN): cv.string,
@@ -406,7 +404,7 @@ class JLRApiHandler:
             return False
 
         _LOGGER.debug("Connected to API")
-        
+
         if len(self.connection.vehicles) > 0:
             _LOGGER.debug(f"Found {len(self.connection.vehicles)} vehicles.  Performing setup")
             _LOGGER.debug(json.dumps(self.connection.vehicles))
@@ -470,7 +468,7 @@ class JLRApiHandler:
             if self.debug_data:
                 _LOGGER.debug(f"ATTRIBUTE DATA - {vehicle.attributes}")
                 _LOGGER.debug(f"STATUS DATA - {status}")
-                
+
         return True
 
     async def async_call_service(self, service):
@@ -519,7 +517,7 @@ class JLRApiHandler:
                     self.vehicles[vehicle].get_status
                 )
                 last_updated = status.get("lastUpdatedTime")
-                
+
                 status_core = {
                     d["key"]: d["value"] for d in status["vehicleStatus"].get("coreStatus")
                 }
@@ -532,14 +530,14 @@ class JLRApiHandler:
                         d["key"]: d["value"] for d in status["vehicleStatus"].get("evStatus")
                     }
                     self.vehicles[vehicle].status_ev = status_ev
-                
-                
+
+
                 _LOGGER.debug(
                     "Received status data update for {}".format(
                         self.vehicles[vehicle].attributes.get("nickname")
                     )
                 )
-                
+
 
                 position = await self.hass.async_add_executor_job(
                     self.vehicles[vehicle].get_position

--- a/custom_components/jlrincontrol/config_flow.py
+++ b/custom_components/jlrincontrol/config_flow.py
@@ -11,8 +11,7 @@ from homeassistant.const import (
     CONF_PIN,
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
-    LENGTH_KILOMETERS,
-    LENGTH_MILES,
+    UnitOfLength,
     UnitOfPressure,
 )
 from homeassistant.core import callback
@@ -174,9 +173,9 @@ class JLRInControlOptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(
                     CONF_DISTANCE_UNIT,
                     default=self.options.get(
-                        CONF_DISTANCE_UNIT, LENGTH_KILOMETERS
+                        CONF_DISTANCE_UNIT, UnitOfLength.KILOMETERS
                     ),
-                ): vol.In(["Default", LENGTH_KILOMETERS, LENGTH_MILES]),
+                ): vol.In(["Default", UnitOfLength.KILOMETERS, UnitOfLength.MILES]),
                 vol.Optional(
                     CONF_PRESSURE_UNIT,
                     default=self.options.get(CONF_PRESSURE_UNIT, UnitOfPressure.BAR),

--- a/custom_components/jlrincontrol/config_flow.py
+++ b/custom_components/jlrincontrol/config_flow.py
@@ -13,8 +13,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     LENGTH_KILOMETERS,
     LENGTH_MILES,
-    PRESSURE_BAR,
-    PRESSURE_PSI,
+    UnitOfPressure,
 )
 from homeassistant.core import callback
 import jlrpy
@@ -38,7 +37,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_USERNAME): str, 
+        vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
         vol.Required(CONF_USE_CHINA_SERVERS, default=False): bool,
     }
@@ -180,8 +179,8 @@ class JLRInControlOptionsFlowHandler(config_entries.OptionsFlow):
                 ): vol.In(["Default", LENGTH_KILOMETERS, LENGTH_MILES]),
                 vol.Optional(
                     CONF_PRESSURE_UNIT,
-                    default=self.options.get(CONF_PRESSURE_UNIT, PRESSURE_BAR),
-                ): vol.In(["Default", PRESSURE_BAR, PRESSURE_PSI]),
+                    default=self.options.get(CONF_PRESSURE_UNIT, UnitOfPressure.BAR),
+                ): vol.In(["Default", UnitOfPressure.BAR, UnitOfPressure.PSI]),
                 vol.Optional(
                     CONF_DEBUG_DATA,
                     default=self.options.get(CONF_DEBUG_DATA, False),

--- a/custom_components/jlrincontrol/const.py
+++ b/custom_components/jlrincontrol/const.py
@@ -3,8 +3,7 @@ from homeassistant.const import (
     ENERGY_KILO_WATT_HOUR,
     UnitOfTemperature,
     UnitOfLength,
-    VOLUME_LITERS,
-    VOLUME_GALLONS,
+    UnitOfVolume,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -66,9 +65,9 @@ JLR_USER_PREF_PARAMS = [
 JLR_TO_HA_UNITS = {
     "distance": {"Km": UnitOfLength.KILOMETERS, "Miles": UnitOfLength.MILES},
     "volume": {
-        "Litre": VOLUME_LITERS,
-        "UkGallons": VOLUME_GALLONS,
-        "UsGallons": VOLUME_GALLONS,
+        "Litre": UnitOfVolume.LITERS,
+        "UkGallons": UnitOfVolume.GALLONS,
+        "UsGallons": UnitOfVolume.GALLONS,
     },
     "temperature": {"Celsius": UnitOfTemperature.CELSIUS, "Fahrenheit": UnitOfTemperature.FAHRENHEIT},
     "distPerVol": {"DistPerVol": "Km/L"},

--- a/custom_components/jlrincontrol/const.py
+++ b/custom_components/jlrincontrol/const.py
@@ -3,8 +3,7 @@ from homeassistant.const import (
     ENERGY_KILO_WATT_HOUR,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
-    LENGTH_KILOMETERS,
-    LENGTH_MILES,
+    UnitOfLength,
     VOLUME_LITERS,
     VOLUME_GALLONS,
 )
@@ -66,7 +65,7 @@ JLR_USER_PREF_PARAMS = [
 ]
 
 JLR_TO_HA_UNITS = {
-    "distance": {"Km": LENGTH_KILOMETERS, "Miles": LENGTH_MILES},
+    "distance": {"Km": UnitOfLength.KILOMETERS, "Miles": UnitOfLength.MILES},
     "volume": {
         "Litre": VOLUME_LITERS,
         "UkGallons": VOLUME_GALLONS,

--- a/custom_components/jlrincontrol/const.py
+++ b/custom_components/jlrincontrol/const.py
@@ -1,8 +1,7 @@
 import logging
 from homeassistant.const import (
     ENERGY_KILO_WATT_HOUR,
-    TEMP_CELSIUS,
-    TEMP_FAHRENHEIT,
+    UnitOfTemperature,
     UnitOfLength,
     VOLUME_LITERS,
     VOLUME_GALLONS,
@@ -71,7 +70,7 @@ JLR_TO_HA_UNITS = {
         "UkGallons": VOLUME_GALLONS,
         "UsGallons": VOLUME_GALLONS,
     },
-    "temperature": {"Celsius": TEMP_CELSIUS, "Fahrenheit": TEMP_FAHRENHEIT},
+    "temperature": {"Celsius": UnitOfTemperature.CELSIUS, "Fahrenheit": UnitOfTemperature.FAHRENHEIT},
     "distPerVol": {"DistPerVol": "Km/L"},
     "energy": {"kWh": ENERGY_KILO_WATT_HOUR},
     "energyPerDist": {"kWhPer100Dist": ENERGY_KILO_WATT_HOUR + "/100m"},

--- a/custom_components/jlrincontrol/const.py
+++ b/custom_components/jlrincontrol/const.py
@@ -1,6 +1,6 @@
 import logging
 from homeassistant.const import (
-    ENERGY_KILO_WATT_HOUR,
+    UnitOfEnergy,
     UnitOfTemperature,
     UnitOfLength,
     UnitOfVolume,
@@ -71,8 +71,8 @@ JLR_TO_HA_UNITS = {
     },
     "temperature": {"Celsius": UnitOfTemperature.CELSIUS, "Fahrenheit": UnitOfTemperature.FAHRENHEIT},
     "distPerVol": {"DistPerVol": "Km/L"},
-    "energy": {"kWh": ENERGY_KILO_WATT_HOUR},
-    "energyPerDist": {"kWhPer100Dist": ENERGY_KILO_WATT_HOUR + "/100m"},
+    "energy": {"kWh": UnitOfEnergy.KILO_WATT_HOUR},
+    "energyPerDist": {"kWhPer100Dist": UnitOfEnergy.KILO_WATT_HOUR + "/100m"},
 }
 
 SENSOR_TYPES = {

--- a/custom_components/jlrincontrol/const.py
+++ b/custom_components/jlrincontrol/const.py
@@ -11,7 +11,7 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = "jlrincontrol"
 DATA_JLR_CONFIG = "jlrincontrol_config"
 JLR_DATA = "jlr_data"
-VERSION = "2.2.4"
+VERSION = "3.0.0"
 
 CONF_USE_CHINA_SERVERS = "use_china_servers"
 

--- a/custom_components/jlrincontrol/device_tracker.py
+++ b/custom_components/jlrincontrol/device_tracker.py
@@ -1,7 +1,7 @@
 """Support for JLR InControl Device Trackers."""
 import logging
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
+from homeassistant.components.device_tracker import SourceType
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from .const import JLR_DATA, DOMAIN
 from .entity import JLREntity
@@ -83,4 +83,4 @@ class JLRDeviceTracker(JLREntity, TrackerEntity):
     @property
     def source_type(self):
         """Return the source type, eg gps or router, of the device."""
-        return SOURCE_TYPE_GPS
+        return SourceType.GPS

--- a/custom_components/jlrincontrol/entity.py
+++ b/custom_components/jlrincontrol/entity.py
@@ -1,6 +1,6 @@
 import logging
 from homeassistant.const import (
-    LENGTH_KILOMETERS,
+    UnitOfLength,
     UnitOfPressure,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -109,7 +109,7 @@ class JLREntity(Entity):
 
     def get_odometer(self, vehicle):
         self.units = self.get_distance_units()
-        if self.units == LENGTH_KILOMETERS:
+        if self.units == UnitOfLength.KILOMETERS:
             return int(int(vehicle.status.get("ODOMETER_METER")) / 1000)
         else:
             return int(vehicle.status.get("ODOMETER_MILES"))

--- a/custom_components/jlrincontrol/entity.py
+++ b/custom_components/jlrincontrol/entity.py
@@ -1,9 +1,7 @@
 import logging
 from homeassistant.const import (
     LENGTH_KILOMETERS,
-    PRESSURE_BAR,
-    PRESSURE_PA,
-    PRESSURE_PSI,
+    UnitOfPressure,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
@@ -104,10 +102,10 @@ class JLREntity(Entity):
         if self._data.pressure_unit and self._data.pressure_unit != "Default":
             return self._data.pressure_unit
         else:
-            if self._hass.config.units.pressure_unit == PRESSURE_PA:
-                return PRESSURE_BAR
+            if self._hass.config.units.pressure_unit == UnitOfPressure.PA:
+                return UnitOfPressure.BAR
             else:
-                return PRESSURE_PSI
+                return UnitOfPressure.PSI
 
     def get_odometer(self, vehicle):
         self.units = self.get_distance_units()

--- a/custom_components/jlrincontrol/manifest.json
+++ b/custom_components/jlrincontrol/manifest.json
@@ -10,5 +10,5 @@
   "requirements": [
     "jlrpy==1.5.2"
   ],
-  "version": "2.2.4"
+  "version": "3.0.0"
 }

--- a/custom_components/jlrincontrol/sensor.py
+++ b/custom_components/jlrincontrol/sensor.py
@@ -7,8 +7,7 @@ from homeassistant.const import (
     PERCENTAGE,
     LENGTH_KILOMETERS,
     LENGTH_METERS,
-    PRESSURE_PA,
-    PRESSURE_BAR,
+    UnitOfPressure,
 )
 from homeassistant.helpers import icon
 from homeassistant.util import dt, unit_conversion
@@ -200,7 +199,7 @@ class JLRVehicleTyreSensor(JLREntity):
                     tyre_pressure = tyre_pressure / 10
 
                 # Convert to local units - metric = bar, imperial = psi
-                if self._units == PRESSURE_BAR:
+                if self._units == UnitOfPressure.BAR:
                     attrs[
                         k.title() + " Pressure ({})".format(self._units)
                     ] = round(tyre_pressure / 100, 2)
@@ -209,7 +208,7 @@ class JLRVehicleTyreSensor(JLREntity):
                         k.title() + " Pressure ({})".format(self._units)
                     ] = round(
                         unit_conversion.PressureConverter.convert(
-                            tyre_pressure * 1000, PRESSURE_PA, self._units
+                            tyre_pressure * 1000, UnitOfPressure.PA, self._units
                         ),
                         1,
                     )
@@ -327,7 +326,7 @@ class JLRVehicleRangeSensor(JLREntity):
         # Has battery
         if self._engine_type == FUEL_TYPE_BATTERY:
             return (
-                self._vehicle.status_ev.get("EV_RANGE_ON_BATTERY_KM", "0") 
+                self._vehicle.status_ev.get("EV_RANGE_ON_BATTERY_KM", "0")
                 if self._units == LENGTH_KILOMETERS
                 else self._vehicle.status_ev.get("EV_RANGE_ON_BATTERY_MILES", "0")
             )
@@ -376,11 +375,11 @@ class JLRVehicleRangeSensor(JLREntity):
             )
 
             attrs["Battery Range"] = (
-                self._vehicle.status_ev.get("EV_RANGE_ON_BATTERY_KM", "0") 
+                self._vehicle.status_ev.get("EV_RANGE_ON_BATTERY_KM", "0")
                 if self._units == LENGTH_KILOMETERS
                 else self._vehicle.status_ev.get("EV_RANGE_ON_BATTERY_MILES", "0")
             )
-        
+
         return attrs
 
 

--- a/custom_components/jlrincontrol/sensor.py
+++ b/custom_components/jlrincontrol/sensor.py
@@ -5,8 +5,7 @@ from homeassistant.components.sensor import SensorDeviceClass
 # from homeassistant.const import STATE_OFF, UNIT_PERCENTAGE
 from homeassistant.const import (
     PERCENTAGE,
-    LENGTH_KILOMETERS,
-    LENGTH_METERS,
+    UnitOfLength,
     UnitOfPressure,
 )
 from homeassistant.helpers import icon
@@ -327,20 +326,20 @@ class JLRVehicleRangeSensor(JLREntity):
         if self._engine_type == FUEL_TYPE_BATTERY:
             return (
                 self._vehicle.status_ev.get("EV_RANGE_ON_BATTERY_KM", "0")
-                if self._units == LENGTH_KILOMETERS
+                if self._units == UnitOfLength.KILOMETERS
                 else self._vehicle.status_ev.get("EV_RANGE_ON_BATTERY_MILES", "0")
             )
         if self._engine_type == FUEL_TYPE_HYBRID:
             return (
                 self._vehicle.status_ev.get("EV_PHEV_RANGE_COMBINED_KM", "0")
-                 if self._units == LENGTH_KILOMETERS
+                 if self._units == UnitOfLength.KILOMETERS
                 else self._vehicle.status_ev.get("EV_PHEV_RANGE_COMBINED_MILES", "0")
             )
         # Fuel only
         return round(
             unit_conversion.DistanceConverter.convert(
                 int(self._vehicle.status.get("DISTANCE_TO_EMPTY_FUEL")),
-                LENGTH_KILOMETERS,
+                UnitOfLength.KILOMETERS,
                 self._units,
             )
         )
@@ -369,14 +368,14 @@ class JLRVehicleRangeSensor(JLREntity):
         if self._engine_type == FUEL_TYPE_HYBRID:
             attrs["Fuel Range"] = round(unit_conversion.DistanceConverter.convert(
                 int(self._vehicle.status.get("DISTANCE_TO_EMPTY_FUEL")),
-                LENGTH_KILOMETERS,
+                UnitOfLength.KILOMETERS,
                 self._units,
                 )
             )
 
             attrs["Battery Range"] = (
                 self._vehicle.status_ev.get("EV_RANGE_ON_BATTERY_KM", "0")
-                if self._units == LENGTH_KILOMETERS
+                if self._units == UnitOfLength.KILOMETERS
                 else self._vehicle.status_ev.get("EV_RANGE_ON_BATTERY_MILES", "0")
             )
 
@@ -414,7 +413,7 @@ class JLREVBatterySensor(JLREntity):
     @property
     def extra_state_attributes(self):
         attrs = {}
-        units = "KM" if self._units == LENGTH_KILOMETERS else "MILES"
+        units = "KM" if self._units == UnitOfLength.KILOMETERS else "MILES"
         s = self._vehicle.status_ev
 
         # Charging status
@@ -491,7 +490,7 @@ class JLRVehicleLastTripSensor(JLREntity):
                             "distance"
                         )
                     ),
-                    LENGTH_METERS,
+                    UnitOfLength.METERS,
                     self._units,
                 )
             )
@@ -531,7 +530,7 @@ class JLRVehicleLastTripSensor(JLREntity):
                 attrs["average_speed"] = round(
                     unit_conversion.DistanceConverter.convert(
                         int(t.get("averageSpeed",0)),
-                        LENGTH_KILOMETERS,
+                        UnitOfLength.KILOMETERS,
                         self._units,
                     )
                 )
@@ -544,7 +543,7 @@ class JLRVehicleLastTripSensor(JLREntity):
                         avg_consumption, 1
                     )
                 else:
-                    if self._units == LENGTH_KILOMETERS:
+                    if self._units == UnitOfLength.KILOMETERS:
                         attrs["average_consumption"] = round(
                             t.get("averageFuelConsumption",0), 1
                         )

--- a/custom_components/jlrincontrol/util.py
+++ b/custom_components/jlrincontrol/util.py
@@ -1,4 +1,4 @@
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import UnitOfTemperature
 
 
 def field_mask(str_value, from_start=0, from_end=0):
@@ -16,7 +16,7 @@ def convert_temp_value(temp_unit, service_code, target_value):
     # Engine start/set rcc value
     if service_code == "REON":
         # Get temp units
-        if temp_unit == TEMP_CELSIUS:
+        if temp_unit == UnitOfTemperature.CELSIUS:
             # Convert from C
             return min(57, max(31, int(target_value * 2)))
         else:
@@ -25,7 +25,7 @@ def convert_temp_value(temp_unit, service_code, target_value):
 
     # Climate preconditioning
     if service_code == "ECC":
-        if temp_unit == TEMP_CELSIUS:
+        if temp_unit == UnitOfTemperature.CELSIUS:
             return min(285, max(155, int(target_value * 10)))
         else:
             # Convert from F

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
     "name": "Jaguar Landrover InControl",
     "render_readme": false,
     "iot_class": "Cloud Polling",
-    "homeassistant": "0.115.0"
+    "homeassistant": "2022.11.0"
 }


### PR DESCRIPTION
Migrate deprecated HA constants to enums:
- `UnitOfPressure` enum introduced in https://github.com/home-assistant/core/pull/81009 and HA `2022.11`
- `UnitOfLength` enum introduced in https://github.com/home-assistant/core/pull/81011 and HA `2022.11`
- `SourceType` enum introduced in https://github.com/home-assistant/core/pull/75892 and HA `2022.9`
- `UnitOfTemperature`  enum introduced in https://github.com/home-assistant/core/pull/81006 and HA `2022.11`
- `UnitOfVolume` enum introduced in https://github.com/home-assistant/core/pull/81028 and HA `2022.11`
- `UnitOfEnergy` enum introduced in https://github.com/home-assistant/core/pull/80998 and HA `2022.11`

Closes #106 