### PR TITLE
chore(services): include which service to use instead of deprecated in warn msg

### DIFF
--- a/custom_components/jlrincontrol/const.py
+++ b/custom_components/jlrincontrol/const.py
@@ -217,15 +217,52 @@ DATA_ATTRS_WINDOW_STATUS = {
 
 SERVICE_STATUS_OK = ["CLEAR", "FUNCTIONING", "NORMAL", "NORMAL_UNBLOCKED"]
 
-DEPRECATED_SERVICES = [
-    "update_health_status",
-    "lock_vehicle",
-    "unlock_vehicle",
-    "reset_alarm",
-    "honk_blink",
-    "start_charging",
-    "stop_charging",
-]
+DEPRECATED_SERVICES = {
+    "update_health_status": {
+        "use_instead_service": "button.press",
+        "use_instead_entity": "Update From Vehicle",
+    },
+    "lock_vehicle": {
+        "use_instead_service": "lock.lock",
+        "use_instead_entity": "Doors",
+    },
+    "unlock_vehicle": {
+        "use_instead_service": "lock.unlock",
+        "use_instead_entity": "Doors",
+    },
+    "reset_alarm": {
+        "use_instead_service": "button.press",
+        "use_instead_entity": "Reset Alarm",
+    },
+    "honk_blink": {
+        "use_instead_service": "button.press",
+        "use_instead_entity": "Honk Blink",
+    },
+    "start_vehicle": {
+        "use_instead_service": "switch.turn_on",
+        "use_instead_entity": "Climate",
+    },
+    "stop_vehicle": {
+        "use_instead_service": "switch.turn_off",
+        "use_instead_entity": "Climate",
+    },
+    "start_charging": {
+        "use_instead_service": "switch.turn_on",
+        "use_instead_entity": "Charging",
+    },
+    "stop_charging": {
+        "use_instead_service": "switch.turn_off",
+        "use_instead_entity": "Charging",
+    },
+    "start_preconditioning": {
+        "use_instead_service": "switch.turn_on",
+        "use_instead_entity": "Preconditioning",
+    },
+    "stop_preconditioning": {
+        "use_instead_service": "switch.turn_off",
+        "use_instead_entity": "Preconditioning",
+    },
+}
 
 SUPPORTED_BUTTON_SERVICES = {
     "ALOFF": {"name": "Reset Alarm", "service": "reset_alarm"},

--- a/custom_components/jlrincontrol/coordinator.py
+++ b/custom_components/jlrincontrol/coordinator.py
@@ -544,10 +544,13 @@ class JLRIncontrolUpdateCoordinator(DataUpdateCoordinator):
             vin_list = []
 
             # Log warning if deprecated service call
-            if service.service in DEPRECATED_SERVICES:
+            if service.service in DEPRECATED_SERVICES.keys():
+                deprecated_service = DEPRECATED_SERVICES[service.service]
                 _LOGGER.warning(
-                    "%s service has been deprecated.  Please update to use the new service for this function",
+                    "%s service has been deprecated from v3.0.0. Please use the service %s with entity %s instead.",
                     service.service,
+                    deprecated_service.get("use_instead_service"),
+                    deprecated_service.get("use_instead_entity")
                 )
 
             # Make list of config_entry_ids and vins


### PR DESCRIPTION
Adjusted the warning message in logs when user calls (directly) on of the deprecated services (see #123).

Messages looks like this now:
```
- update_health_status service has been deprecated from v3.0.0. Please use the service button.press with entity Update From Vehicle instead.
- lock_vehicle service has been deprecated from v3.0.0. Please use the service lock.lock with entity Doors instead.
- unlock_vehicle service has been deprecated from v3.0.0. Please use the service lock.unlock with entity Doors instead.
- reset_alarm service has been deprecated from v3.0.0. Please use the service button.press with entity Reset Alarm instead.
- honk_blink service has been deprecated from v3.0.0. Please use the service button.press with entity Honk Blink instead.
- start_vehicle service has been deprecated from v3.0.0. Please use the service switch.turn_on with entity Climate instead.
- stop_vehicle service has been deprecated from v3.0.0. Please use the service switch.turn_off with entity Climate instead.
- start_charging service has been deprecated from v3.0.0. Please use the service switch.turn_on with entity Charging instead.
- stop_charging service has been deprecated from v3.0.0. Please use the service switch.turn_off with entity Charging instead.
- start_preconditioning service has been deprecated from v3.0.0. Please use the service switch.turn_on with entity Preconditioning instead.
- stop_preconditioning service has been deprecated from v3.0.0. Please use the service switch.turn_off with entity Preconditioning instead.
```

In addition to modifying the warn message, I have also included following services in the `DEPRECATED_SERVICES` dict, that exists in v2.5.5 and has been converted to switches in v3.0.0:
- `start_vehicle`
- `stop_vehicle`
- `start_preconditioning`
- `stop_preconditioning`